### PR TITLE
Only prevent click event when drag is in relevant direction

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -498,7 +498,9 @@ export default class ScrollBooster {
 
         this.events.click = (event) => {
             const state = this.getState();
-            if (Math.abs(Math.max(state.dragOffset.x, state.dragOffset.y)) > CLICK_EVENT_THRESHOLD_PX) {
+            const dragOffsetX = this.props.direction !== 'vertical' ? state.dragOffset.x : 0;
+            const dragOffsetY = this.props.direction !== 'horizontal' ? state.dragOffset.y : 0;
+            if (Math.abs(Math.max(dragOffsetX, dragOffsetY)) > CLICK_EVENT_THRESHOLD_PX) {
                 event.preventDefault();
                 event.stopPropagation();
             }


### PR DESCRIPTION
Stops irrelevant axis based on direction prop (which can be "horizontal" or "vertical" or "any") from affecting click event prevention